### PR TITLE
amend find-map-by-id to accept fields as 3rd parameter

### DIFF
--- a/src/monger/collection.clj
+++ b/src/monger/collection.clj
@@ -168,7 +168,7 @@
   "Returns a single object converted to Map from this collection matching the query."
   ([^String collection ^Map ref]
      (from-db-object ^DBObject (find-one collection ref) true))
-  ([^String collection ^Map ref fields]
+  ([^String collection ^Map ref ^List fields]
      (from-db-object ^DBObject (find-one collection ref fields) true))
   ([^String collection ^Map ref ^List fields keywordize]
      (from-db-object ^DBObject (find-one collection ref fields) keywordize)))
@@ -205,9 +205,9 @@
   ([^String collection id]
      (check-not-nil! id "id must not be nil")
      (from-db-object ^DBObject (find-one-as-map collection { :_id id }) true))
-  ([^String collection id keywordize]
-     (check-not-nil! id "id must not be nil")
-     (from-db-object ^DBObject (find-one-as-map collection { :_id id }) keywordize))
+  ([^String collection id ^List fields]
+     (check-not-nil! id "id must not be nil")  
+     (from-db-object ^DBObject (find-one-as-map collection { :_id id } fields) true))
   ([^String collection id ^List fields keywordize]
      (check-not-nil! id "id must not be nil")
      (from-db-object ^DBObject (find-one-as-map collection { :_id id } fields) keywordize)))

--- a/test/monger/test/atomic_modifiers.clj
+++ b/test/monger/test/atomic_modifiers.clj
@@ -74,7 +74,7 @@
         oid  (ObjectId.)]
     (mgcol/insert coll { :_id oid :weight 10.0 :height 15.2 })
     (mgcol/update coll { :_id oid } { $set { :weight 20.5 :height 25.6 } })
-    (is (= { :_id oid :weight 20.5 :height 25.6 } (mgcol/find-map-by-id coll oid [:weight])))))
+    (is (= { :_id oid :weight 20.5 :height 25.6 } (mgcol/find-map-by-id coll oid [:weight :height])))))
 
 
 (deftest update-and-set-multiple-fields-using-$set-modifier
@@ -82,7 +82,7 @@
         oid  (ObjectId.)]
     (mgcol/insert coll { :_id oid :weight 10.0 })
     (mgcol/update coll { :_id oid } {$set { :weight 20.5 :height 25.6 } })
-    (is (= { :_id oid :weight 20.5 :height 25.6 } (mgcol/find-map-by-id coll oid [:weight])))))
+    (is (= { :_id oid :weight 20.5 :height 25.6 } (mgcol/find-map-by-id coll oid [:weight :height])))))
 
 
 ;;

--- a/test/monger/test/regular_finders.clj
+++ b/test/monger/test/regular_finders.clj
@@ -162,9 +162,13 @@
 (deftest find-partial-document-as-map-by-id-when-document-does-exist
   (let [collection "libraries"
         doc-id     (monger.util/random-uuid)
-        doc        { :data-store "MongoDB", :language "Clojure", :_id doc-id }]
-    (mgcol/insert collection doc)
-    (is (= ({ :language "Clojure" } (mgcol/find-map-by-id collection doc-id [ :language ]))))))
+        fields     [:data-store]                
+        doc        { :data-store "MongoDB", :language "Clojure", :_id doc-id }
+        _          (mgcol/insert collection doc)        
+        loaded     (mgcol/find-map-by-id collection doc-id [ :language ])]      
+    (is (= { :language "Clojure", :_id doc-id } loaded ))
+  )
+)
 
 
 ;;


### PR DESCRIPTION
maintaining consistency in the api by accepting fields before keywordize.
A couple of the tests were already using fields as a parameter, which was silently being ignored. Tests passed because specific fields were inspected rather than the entire document structure.
