### PR TITLE
Eliminate some reflection via adding type hints, and correcting one

### DIFF
--- a/src/clojure/monger/ring/session_store.clj
+++ b/src/clojure/monger/ring/session_store.clj
@@ -26,7 +26,7 @@
 (defrecord ClojureReaderBasedMongoDBSessionStore [^String collection-name])
 
 (defmethod print-dup java.util.Date
-  [^java.util.Date d ^java.io.OutputStream out]
+  [^java.util.Date d ^java.io.Writer out]
   (.write out
           (str "#="
                `(java.util.Date. ~(.getYear d)
@@ -37,7 +37,7 @@
                                  ~(.getSeconds d)))))
 
 (defmethod print-dup org.bson.types.ObjectId
-  [oid out]
+  [oid ^java.io.Writer out]
   (.write out
           (str "#="
                `(org.bson.types.ObjectId. ~(str oid)))))


### PR DESCRIPTION
I am pretty sure that the print-dup method always takes a java.io.Writer as its second argument, not a java.io.OutputStream.  java.io.OutputStream has no write method whose argument is a string, only byte arrays or an int to write a single byte.
