### PR TITLE
$setOnInsert operator

### DIFF
--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -125,6 +125,13 @@
 ;;   (monger.collection/update "things" { :_id oid } { $unset { :weight 1 } })
 (defoperator $unset)
 
+;; $setOnInsert assigns values to fields during an upsert only when using the upsert option to the update operation performs an insert.
+;; New in version 2.4. http://docs.mongodb.org/manual/reference/operator/setOnInsert/
+;;
+;; EXAMPLES:
+;;   (monger.collection/find-and-modify "things" {:_id oid} {$set {:lastseen now} $setOnInsert {:firstseen now}} :upsert true)
+(defoperator $setOnInsert)
+
 ;; $rename renames a given field
 ;;
 ;; EXAMPLES:

--- a/test/monger/test/atomic_modifiers_test.clj
+++ b/test/monger/test/atomic_modifiers_test.clj
@@ -114,6 +114,25 @@
     (is (mgres/ok? (mgcol/update coll { :_id oid } { $unset { :published 1 :featured true } })))
     (is (= { :_id oid :title "Document 1" } (mgcol/find-map-by-id coll oid)))))
 
+;;
+;; $setOnInsert
+;;
+
+(deftest setOnInsert-in-upsert-for-non-existing-document
+  (let [coll "docs"
+        now  456
+        oid  (ObjectId.)]
+    (mgcol/find-and-modify coll {:_id oid} {$set {:lastseen now} $setOnInsert {:firstseen now}} :upsert true)
+    (is (= { :_id oid :lastseen now :firstseen now} (mgcol/find-map-by-id coll oid)))))
+
+(deftest setOnInsert-in-upsert-for-existing-document
+  (let [coll   "docs"
+        before 123
+        now    456
+        oid    (ObjectId.)]
+    (mgcol/insert coll { :_id oid :firstseen before :lastseen before})
+    (mgcol/find-and-modify coll {:_id oid} {$set {:lastseen now} $setOnInsert {:firstseen now}} :upsert true)
+    (is (= { :_id oid :lastseen now :firstseen before} (mgcol/find-map-by-id coll oid)))))
 
 ;;
 ;; $push


### PR DESCRIPTION
Operator `$setOnInsert` and tests for it. New in Mongo 2.4.

http://docs.mongodb.org/manual/reference/operator/setOnInsert/
