### PR TITLE
Fix:  must return ids in creation order

### DIFF
--- a/src/clojure/monger/ragtime.clj
+++ b/src/clojure/monger/ragtime.clj
@@ -24,7 +24,7 @@
       (let [xs (with-collection migrations-collection
                  (find {})
                  (sort {:created_at 1}))]
-        (set (map :_id xs))))))
+        (vec (map :_id xs))))))
 
 
 (defn flush-migrations!


### PR DESCRIPTION
As I started adding some migrations, I started to get migration conflict exceptions coming from ragtime, like the following:

```
java.lang.Exception: Conflict! Expected {:id "default-admin-user-is-system-user", :up #<migration$with_logging_fn$fn__1507 reef.db.migration$with_logging_fn$fn__1507@2a099dd9>, :down #<migration$with_logging_fn$fn__1507 reef.db.migration$with_logging_fn$fn__1507@5d5a271e>} but {:id "fieldsmeta-roles-descriptions", :up #<migration$with_logging_fn$fn__1507 reef.db.migration$with_logging_fn$fn__1507@49be5273>, :down #<migration$with_logging_fn$fn__1507 reef.db.migration$with_logging_fn$fn__1507@6e1721d7>} was applied.
        at ragtime.strategy$raise_error.invoke(strategy.clj:40)
```

I traced it down to monger.ragtime/applied-migration-ids not preserving insertion order of the Ids.

The code runs a query for the ids sorting by creation time. However, it puts the results into a `set`, effectively loosing the ordering.

I added a test case and changed it to return a vector instead.

Note: This _might_ break some client code compatibility... but I'd argue there's a low chance of that happening since this is mostly an internal protocol used by ragtime. And I'd say it's a good time now given the 1.6.0 release.

Thanks
