### PR TITLE
Use local binding instead of dynamic global for collection. Fixes #68

### DIFF
--- a/src/clojure/monger/query.clj
+++ b/src/clojure/monger/query.clj
@@ -26,8 +26,6 @@
 ;; Implementation
 ;;
 
-(def ^{:dynamic true} *query-collection*)
-
 ;;
 ;; Cursor/chain methods
 ;;
@@ -135,11 +133,12 @@
 
 (defmacro with-collection
   [^String coll & body]
-  `(binding [*query-collection* (if (string? ~coll)
-                                  (.getCollection ^DB monger.core/*mongodb-database* ~coll)
-                                  ~coll)]
-     (let [query# (-> (empty-query *query-collection*) ~@body)]
-       (exec query#))))
+  `(let [coll# ~coll
+         db-coll# (if (string? coll#)
+                    (.getCollection ^DB monger.core/*mongodb-database* ^String coll#)
+                    coll#)
+         query# (-> (empty-query db-coll#) ~@body)]
+     (exec query#)))
 
 (defmacro partial-query
   [& body]


### PR DESCRIPTION
Removes dynamic global `*query-collection*` and instead uses a local binding inside `with-collection`. In addition, binds `~coll` locally to avoid evaluating it more than once in the expansion of the macro.

The full test suite still passes (with the exception of a class version mismatch against Clojure 1.4 with something in mongo.conversion, which failed before I made any changes).
