### PR TITLE
Support for $each modifier

### DIFF
--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -147,8 +147,18 @@
 ;;   (mgcol/update "docs" { :_id oid } { $push { :tags "modifiers" } })
 (defoperator $push)
 
+;; $each is a modifier for the $push and $addToSet operators for appending multiple values to an array field.
+;; Without the $each modifier $push and $addToSet will append an array as a single value.
+;; MongoDB 2.4 adds support for the $each modifier to the $push operator.
+;; In MongoDB 2.2 the $each modifier can only be used with the $addToSet operator.
+;;
+;; EXAMPLES:
+;;   (mgcol/update coll { :_id oid } { $push { :tags { $each ["mongodb" "docs"] } } })
+(defoperator $each)
+
 ;; $pushAll appends each value in value_array to field, if field is an existing array, otherwise sets field to the array value_array
 ;; if field is not present. If field is present but is not an array, an error condition is raised.
+;; Deprecated since MongoDB 2.4, $push with $each modifier should be used instead.
 ;;
 ;; EXAMPLES:
 ;;   (mgcol/update coll { :_id oid } { $pushAll { :tags ["mongodb" "docs"] } })

--- a/test/monger/test/atomic_modifiers_test.clj
+++ b/test/monger/test/atomic_modifiers_test.clj
@@ -197,6 +197,37 @@
              (mc/find-map-by-id db coll oid)))))
 
   ;;
+  ;; $push $each
+  ;;
+
+  (deftest initialize-an-array-using-$push-$each-modifier
+    (let [coll  "docs"
+          oid   (ObjectId.)
+          title "$push with $each modifier appends multiple values to field"]
+      (mc/insert db coll {:_id oid :title title})
+      (mc/update db coll {:_id oid} {$push {:tags {$each ["mongodb" "docs"]}}})
+      (is (= {:_id oid :title title :tags ["mongodb" "docs"]}
+             (mc/find-map-by-id db coll oid)))))
+
+  (deftest add-values-to-an-existing-array-using-$push-$each-modifier
+    (let [coll  "docs"
+          oid   (ObjectId.)
+          title "$push with $each modifier appends multiple values to field"]
+      (mc/insert db coll {:_id oid :title title :tags ["mongodb"]})
+      (mc/update db coll {:_id oid} {$push {:tags {$each ["modifiers" "docs"]}}})
+      (is (= {:_id oid :title title :tags ["mongodb" "modifiers" "docs"]}
+             (mc/find-map-by-id db coll oid)))))
+
+  (deftest double-add-value-to-an-existing-array-using-$push-$each-modifier
+    (let [coll  "docs"
+          oid   (ObjectId.)
+          title "$push with $each modifier appends multiple values to field"]
+      (mc/insert db coll {:_id oid :title title :tags ["mongodb" "docs"]})
+      (mc/update db coll {:_id oid} {$push {:tags {$each ["modifiers" "docs"]}}})
+      (is (= {:_id oid :title title :tags ["mongodb" "docs" "modifiers" "docs"]}
+             (mc/find-map-by-id db coll oid)))))
+
+  ;;
   ;; $pushAll
   ;;
 
@@ -262,6 +293,36 @@
       (is (= {:_id oid :title title :tags ["mongodb" "modifiers"]}
              (mc/find-map-by-id db coll oid)))))
 
+  ;;
+  ;; $addToSet $each
+  ;;
+
+  (deftest initialize-an-array-using-$addToSet-$each-modifier
+    (let [coll  "docs"
+          oid   (ObjectId.)
+          title "$addToSet with $each modifier appends multiple values to field unless they are already there"]
+      (mc/insert db coll {:_id oid :title title})
+      (mc/update db coll {:_id oid} {$addToSet {:tags {$each ["mongodb" "docs"]}}})
+      (is (= {:_id oid :title title :tags ["mongodb" "docs"]}
+             (mc/find-map-by-id db coll oid)))))
+
+  (deftest add-values-to-an-existing-array-using-$addToSet-$each-modifier
+    (let [coll  "docs"
+          oid   (ObjectId.)
+          title "$addToSet with $each modifier appends multiple values to field unless they are already there"]
+      (mc/insert db coll {:_id oid :title title :tags ["mongodb"]})
+      (mc/update db coll {:_id oid} {$addToSet {:tags {$each ["modifiers" "docs"]}}})
+      (is (= {:_id oid :title title :tags ["mongodb" "modifiers" "docs"]}
+             (mc/find-map-by-id db coll oid)))))
+
+  (deftest double-add-value-to-an-existing-array-using-$addToSet-$each-modifier
+    (let [coll  "docs"
+          oid   (ObjectId.)
+          title "$addToSet with $each modifier appends multiple values to field unless they are already there"]
+      (mc/insert db coll {:_id oid :title title :tags ["mongodb" "docs"]})
+      (mc/update db coll {:_id oid} {$addToSet {:tags {$each ["modifiers" "docs" "operators"]}}})
+      (is (= {:_id oid :title title :tags ["mongodb" "docs" "modifiers" "operators"]}
+             (mc/find-map-by-id db coll oid)))))
 
   ;;
   ;; $pop


### PR DESCRIPTION
Added $each modifier (with tests) for $addToSet and $push operators. $pushAll is deprecated since MongoDB 2.4, $push with $each modifier should be used instead.
