### PR TITLE
Allow object-id to convert string to object-id

### DIFF
--- a/src/clojure/monger/util.clj
+++ b/src/clojure/monger/util.clj
@@ -30,9 +30,11 @@
   (.toString (new BigInteger n (SecureRandom.)) num-base))
 
 (defn ^ObjectId object-id
-  "Returns a new BSON object id"
-  []
-  (ObjectId.))
+  "Returns a new BSON object id, or converts str to BSON object id"
+  ([]
+     (ObjectId.))
+  ([s]
+     (ObjectId. s)))
 
 (defprotocol GetDocumentId
   (get-id  [input] "Returns document id"))


### PR DESCRIPTION
I was using this alot in my own projects (object-id from string), and I don't see any reason why it can't be in monger itself.
