### PR TITLE
Exclude clojure.core/update from monger.collection.

### DIFF
--- a/src/clojure/monger/collection.clj
+++ b/src/clojure/monger/collection.clj
@@ -23,7 +23,7 @@
    * http://clojuremongodb.info/articles/updating.html
    * http://clojuremongodb.info/articles/deleting.html
    * http://clojuremongodb.info/articles/aggregation.html"
-  (:refer-clojure :exclude [find remove count drop distinct empty?])
+  (:refer-clojure :exclude [find remove count drop distinct empty? update])
   (:import [com.mongodb Mongo DB DBCollection WriteResult DBObject WriteConcern 
             DBCursor MapReduceCommand MapReduceCommand$OutputType]
            [java.util List Map]


### PR DESCRIPTION
clojure.core/update was introduced in clojure 1.7. To avoid clashing
with monger.collection/update it should be excluded in the latter
namespace.
