### PR TITLE
Add BSONTimestamp to json serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ deploy.docs.sh
 target/*
 .idea/
 *.iml
+.nrepl-port

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ checkouts/*
 doc/*
 deploy.docs.sh
 target/*
+.idea/
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -39,6 +39,7 @@
              :dev {:resource-paths ["test/resources"]
                    :dependencies  [[clj-time               "0.8.0" :exclusions [org.clojure/clojure]]
                                    [cheshire               "5.3.1" :exclusions [org.clojure/clojure]]
+                                   [org.clojure/data.json  "0.2.5" :exclusions [org.clojure/clojure]]
                                    [org.clojure/tools.cli  "0.3.1" :exclusions [org.clojure/clojure]]
                                    [org.clojure/core.cache "0.6.3" :exclusions [org.clojure/clojure]]
                                    [ring/ring-core         "1.3.0" :exclusions [org.clojure/clojure]]

--- a/test/monger/test/json_cheshire_test.clj
+++ b/test/monger/test/json_cheshire_test.clj
@@ -1,0 +1,16 @@
+(ns monger.test.json-cheshire-test
+  (:require [clojure.test :refer :all]
+    [monger.json]
+    [cheshire.core :refer :all])
+  (:import org.bson.types.ObjectId
+           org.bson.types.BSONTimestamp))
+
+(deftest convert-dbobject-to-json
+  (let [input (ObjectId.)
+        output (generate-string input)]
+    (is (= (str "\"" input "\"") output))))
+
+(deftest convert-bson-timestamp-to-json
+  (let [input (BSONTimestamp. 123 4)
+        output (generate-string input)]
+    (is (= "{\"time\":123,\"inc\":4}" output))))

--- a/test/monger/test/json_test.clj
+++ b/test/monger/test/json_test.clj
@@ -1,0 +1,16 @@
+(ns monger.test.json-test
+  (:require [clojure.test :refer :all]
+    [monger.json]
+    [clojure.data.json :as json])
+  (:import org.bson.types.ObjectId
+           org.bson.types.BSONTimestamp))
+
+(deftest convert-dbobject-to-json
+  (let [input (ObjectId.)
+        output (json/write-str input)]
+    (is (= (str "\"" input "\"") output))))
+
+(deftest convert-bson-timestamp-to-json
+  (let [input (BSONTimestamp. 123 4)
+        output (json/write-str input)]
+    (is (= "{\"time\":123,\"inc\":4}" output))))


### PR DESCRIPTION
Adds BSONTimestamp serialization to JSON for clojure.data.json (2.x) and cheshire, along with a couple of tests to validate each transformation.