### PR TITLE
Connect via uri in core/connect if it is passed

### DIFF
--- a/src/clojure/monger/core.clj
+++ b/src/clojure/monger/core.clj
@@ -90,12 +90,14 @@
            (MongoClient. server-list creds options))
        (MongoClient. ^ServerAddress server-address options))))
   ([{ :keys [host port uri] :or { host *mongodb-host* port *mongodb-port* }}]
-     (MongoClient. ^String host ^Long port)))
+    (if uri
+       (MongoClient. (MongoClientURI. uri))
+       (MongoClient. ^String host ^Long port))))
 
 (defn ^MongoClient connect-with-credentials
   "Connect with provided credentials and default options"
   ([credentials]
-     (connect-with-credentials *mongodb-host* *mongodb-port* credentials))  
+     (connect-with-credentials *mongodb-host* *mongodb-port* credentials))
   ([^String hostname credentials]
      (connect-with-credentials hostname *mongodb-port* credentials))
   ([^String hostname port credentials]


### PR DESCRIPTION
core/connect ignores :uri key and tries to connect 127.0.0.1:27017 instead.
Patch fix this behaviour by checking uri key existance and trying to connect
by uri if it's provided.