### PR TITLE
Fix 5-arity ensure-index by renaming `name` argument

### DIFF
--- a/src/clojure/monger/collection.clj
+++ b/src/clojure/monger/collection.clj
@@ -422,10 +422,10 @@
      (.createIndex (.getCollection db (name coll))
                    (as-field-selector keys)
                    (to-db-object options)))
-  ([^DB db ^String coll ^Map keys ^String name unique?]
+  ([^DB db ^String coll ^Map keys ^String index-name unique?]
      (.createIndex (.getCollection db (name coll))
                    (as-field-selector keys)
-                   name
+                   index-name
                    unique?)))
 
 

--- a/test/monger/test/indexing_test.clj
+++ b/test/monger/test/indexing_test.clj
@@ -26,6 +26,8 @@
       (mc/ensure-index db collection (array-map "language" 1))
       (mc/drop-indexes db collection)
       (mc/ensure-index db collection (array-map "language" 1) {:unique true})
+      (mc/drop-indexes db collection)
+      (mc/ensure-index db collection (array-map "language" 1) "index-name" true)
       (mc/drop-indexes db collection)))
 
   (deftest ^{:indexing true :time-consuming true} test-ttl-collections


### PR DESCRIPTION
The 5-arity ensure-index has a bug that causes it throw an exception when used. The `name` argument shadows clojure.core/name so that that function cannot be called within the function.

Fixed this issue by renaming the argument from `name` to `index-name`.

This PR includes a unit test that fails without this fix.