### PR TITLE
Monger calls removed com.mongodb.MongoClientOptions$Builder methods

### DIFF
--- a/src/clojure/monger/core.clj
+++ b/src/clojure/monger/core.clj
@@ -137,7 +137,7 @@
   [{:keys [connections-per-host threads-allowed-to-block-for-connection-multiplier
            max-wait-time connect-timeout socket-timeout socket-keep-alive auto-connect-retry max-auto-connect-retry-time
            description write-concern cursor-finalizer-enabled read-preference
-           required-replica-set-name] :or [auto-connect-retry true]}]
+           required-replica-set-name]}]
   (let [mob (MongoClientOptions$Builder.)]
     (when connections-per-host
       (.connectionsPerHost mob connections-per-host))
@@ -151,11 +151,6 @@
       (.socketTimeout mob socket-timeout))
     (when socket-keep-alive
       (.socketKeepAlive mob socket-keep-alive))
-    (when auto-connect-retry
-      (.autoConnectRetry mob auto-connect-retry))
-    ;; deprecated
-    (when max-auto-connect-retry-time
-      (.maxAutoConnectRetryTime mob max-auto-connect-retry-time))
     (when read-preference
       (.readPreference mob read-preference))
     (when description

--- a/test/monger/test/core_test.clj
+++ b/test/monger/test/core_test.clj
@@ -55,3 +55,18 @@
         dbs  (mg/get-db-names conn)]  
     (is (not (empty? dbs)))
     (is (dbs "monger-test"))))
+
+(deftest monger-options-test
+  (let [opts {:connections-per-host 1
+              :threads-allowed-to-block-for-connection-multiplier 1
+              :max-wait-time 1
+              :connect-timeout 1
+              :socket-timeout 1
+              :socket-keep-alive true
+              :auto-connect-retry true
+              :max-auto-connect-retry-time 1
+              :description "Description"
+              :write-concern com.mongodb.WriteConcern/JOURNAL_SAFE
+              :cursor-finalizer-enabled true
+              :required-replica-set-name "rs"}]
+    (is (instance? com.mongodb.MongoClientOptions$Builder (mg/mongo-options-builder opts)))))


### PR DESCRIPTION
`MongoClientOptions.Builder#maxAutoConnectRetryTime` and `MongoClientOptions.Builder#autoConnectRetry` were removed in the 3.x java client but are still called by monger if provided.

BTW; the default `:or [auto-connect-retry true]` obviously didn't work (should have been `:or {auto-connect-retry true}`) so it didn't fail when the deprecated methods were removed :) 