### PR TITLE
Keywordise find maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ deploy.docs.sh
 target/*
 todo.org
 .nrepl-*
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Monger is part of the [group of Clojure libraries known as ClojureWerkz](http://
 
 Monger uses [Leiningen 2](https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md). Make sure you have it installed and then run tests against
 supported Clojure versions using
-
+    
+    ./bin/ci/before_script.sh
     lein all do clean, javac, test
 
 Then create a branch and make your changes on it. Once you are done with your changes and all tests pass, submit a pull request

--- a/src/clojure/monger/collection.clj
+++ b/src/clojure/monger/collection.clj
@@ -147,8 +147,10 @@
      (with-open [dbc (find db coll ref)]
        (map (fn [x] (from-db-object x true)) dbc)))
   ([^DB db ^String coll ^Map ref fields]
+     (find-maps db coll ref fields true))
+  ([^DB db ^String coll ^Map ref fields keywordize]
      (with-open [dbc (find db coll ref fields)]
-       (map (fn [x] (from-db-object x true)) dbc))))
+       (map (fn [x] (from-db-object x keywordize)) dbc))))
 
 (defn find-seq
   "Queries for objects in this collection, returns ISeq of DBObjects."

--- a/test/monger/test/regular_finders_test.clj
+++ b/test/monger/test/regular_finders_test.clj
@@ -281,4 +281,12 @@
         (doseq [i clojure-libs]
           (let [doc (mgcnv/from-db-object i true)]
             (is (= (:language doc) "Clojure"))))
-        (is (empty? (mc/find db collection { :language "Erlang" } [:name])))))))
+        (is (empty? (mc/find db collection { :language "Erlang" } [:name]))))))
+
+  (deftest find-maps-with-keywordize-false
+    (let [collection "libraries"]
+      (mc/insert-batch db collection [{ :language "Clojure", :name "monger" }
+                                      { :language "Clojure", :name "langohr" }])
+      (let [results (mc/find-maps db collection {:name "langohr"} [] false)]
+        (is (= 1 (.count results)))
+        (is (= (get (first results) "language") "Clojure"))))))


### PR DESCRIPTION
Added an optional keywordize argument to ```find-maps```, (similar to find-one-as-map), so that the results of the function can optionally be returned with the map keys as strings.