### PR TITLE
Updating README: how to get ride of the verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ hesitate to join our [mailing
 list](https://groups.google.com/forum/#!forum/clojure-mongodb) and ask
 questions, too!
 
+From the `3.0.0-beta` MongoDB Java driver, all logging was switched to 
+SLF4J 
+([reference](https://groups.google.com/d/msg/mongodb-user/_t5rHlaxYxI/aNdlMVIrcR0J)).
+To get ride of the verbose logging from the driver, add the following
+artifact to your dependencies:
+
+    [org.slf4j/slf4j-nop "1.7.12"]
+
+
 
 ## Documentation & Examples
 


### PR DESCRIPTION
An instruction to get ride of logging messages from the driver was added
to the README file. A reference to the solution's source was also given.