### PR TITLE
Fix cursor hinting

### DIFF
--- a/src/clojure/monger/query.clj
+++ b/src/clojure/monger/query.clj
@@ -106,7 +106,7 @@
     (when snapshot
       (.snapshot cursor))
     (when hint
-      (.hint (to-db-object hint)))
+      (.hint cursor (to-db-object hint)))
     (when read-preference
       (.setReadPreference cursor read-preference))
     (when options


### PR DESCRIPTION
**Problem**

When hinting a cursor an exception is thrown on execution of the query.

```IllegalArgumentException No matching field found: hint for class com.mongodb.BasicDBObject  clojure.lang.Reflector.getInstanceField (Reflector.java:271)```

**Solution**

The .hint method should be applied on the cursor object instead
of the DBObject contained in the hint field.

