### PR TITLE
with-collection macro: type hints improvement

### DIFF
--- a/src/clojure/monger/query.clj
+++ b/src/clojure/monger/query.clj
@@ -167,10 +167,11 @@
   (merge m { :limit per-page :skip (monger.internal.pagination/offset-for page per-page) }))
 
 (defmacro with-collection
-  [^DB db ^String coll & body]
+  [db coll & body]
   `(let [coll# ~coll
+         ^DB db# ~db
          db-coll# (if (string? coll#)
-                    (.getCollection ~db ^String coll#)
+                    (.getCollection db# coll#)
                     coll#)
          query# (-> (empty-query db-coll#) ~@body)]
      (exec query#)))


### PR DESCRIPTION
From all the resources I found about type hinting in macros,
it doesn't work like it does for normal functions.

I got reflection warnings for a code like this:

```clj
(let [conn (mg/connect)
      db (delay (mg/get-db conn "monger-test"))]
  (with-collection @db "something"
    (find {})))
```

The type hint for `db` didn't work. Actually the type hint that works
comes from the function `core/get-db` and we see this when we remove
`delay` from the code above. As we could expect, the function `deref`
doesn't propagate the type hint.

I did similar tests with the collection name and no reflection warning
was raised for any case. In addition, it looked weird for me to have
a type hint like `^String` and then a checking like `string?` later.

Some references:

* http://stackoverflow.com/questions/11919602/generating-clojure-code-with-type-hints
* Clojure High Performance Programming, page 44.