### PR TITLE
Fix keywordize param for find-map-by-id

### DIFF
--- a/src/clojure/monger/collection.clj
+++ b/src/clojure/monger/collection.clj
@@ -226,13 +226,13 @@
   "Returns a single object, converted to map with matching _id field."
   ([^DB db ^String coll id]
      (check-not-nil! id "id must not be nil")
-     (from-db-object ^DBObject (find-one-as-map db coll {:_id id}) true))
+     (find-one-as-map db coll {:_id id}))
   ([^DB db ^String coll id fields]
      (check-not-nil! id "id must not be nil")
-     (from-db-object ^DBObject (find-one-as-map db coll {:_id id} fields) true))
+     (find-one-as-map db coll {:_id id} fields))
   ([^DB db ^String coll id fields keywordize]
      (check-not-nil! id "id must not be nil")
-     (from-db-object ^DBObject (find-one-as-map db coll {:_id id} fields) keywordize)))
+     (find-one-as-map db coll {:_id id} fields keywordize)))
 
 ;;
 ;; monger.collection/count


### PR DESCRIPTION
Calling `from-db-object` in `find-map-by-id` is redundant since the same method is called in `find-one-as-map`.
Also this commit fixes keywordize params. Prior it `find-map-by-id` always returns symbolized keys.