### PR TITLE
Add missing operators

### DIFF
--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -80,6 +80,12 @@
 ;;   (mgcol/find-maps "languages" { :tags { $nin [ "functional" ] } } )
 (defoperator $nin)
 
+;; $eq is "equals" comparator
+;;
+;; EXAMPLES:
+;;   (monger.collection/find "libraries" { :language { $eq "Clojure" }})
+(defoperator $eq)
+
 ;; $ne is "non-equals" comparator
 ;;
 ;; EXAMPLES:

--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -96,6 +96,13 @@
 (defoperator $regex)
 (defoperator $options)
 
+;; Matches documents that satisfy a JavaScript expression.
+;;
+;; EXAMPLES:
+;;
+;;   (monger.collection/find "people" { $where "this.placeOfBirth === this.address.city" })
+(defoperator $where)
+
 ;;
 ;; LOGIC OPERATORS
 ;;

--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -314,3 +314,9 @@
 ;; EXAMPLES:
 ;;   (mgcol/update coll { :_id oid } { $currentDate { :lastModified true } })
 (defoperator $currentDate)
+
+;; Isolates intermediate multi-document updates from other clients.
+;;
+;; EXAMPLES:
+;;   (mgcol/update "libraries" { :language "Clojure", $isolated 1 } { $inc { :popularity 1 } } {:multi true})
+(defoperator $isolated)

--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -275,9 +275,18 @@
 (defoperator $ifNull)
 (defoperator $cond)
 
+;; Geospatial
 (defoperator $geoWithin)
 (defoperator $geoIntersects)
 (defoperator $near)
+(defoperator $nearSphere)
+(defoperator $geometry)
+(defoperator $maxDistance)
+(defoperator $minDistance)
+(defoperator $center)
+(defoperator $centerSphere)
+(defoperator $box)
+(defoperator $polygon)
 
 (defoperator $slice)
 

--- a/src/clojure/monger/operators.clj
+++ b/src/clojure/monger/operators.clj
@@ -83,7 +83,7 @@
 ;; $ne is "non-equals" comparator
 ;;
 ;; EXAMPLES:
-;;   (monger.collection/find "libraries" {$ne { :language "Clojure" }})
+;;   (monger.collection/find "libraries" { :language { $ne "Clojure" }})
 (defoperator $ne)
 
 ;; $elemMatch checks if an element in an array matches the specified expression

--- a/test/monger/test/query_operators_test.clj
+++ b/test/monger/test/query_operators_test.clj
@@ -64,7 +64,7 @@
                                       {:language "Clojure" :name "langohr"  :users 5}
                                       {:language "Clojure" :name "incanter" :users 15}
                                       {:language "Scala"   :name "akka"     :users 150}])
-      (is (= 2 (.count (mc/find db collection {$ne {:language "Clojure"}}))))))
+      (is (= 2 (.count (mc/find db collection {:language {$ne "Clojure"}}))))))
 
 
   ;;

--- a/test/monger/test/query_operators_test.clj
+++ b/test/monger/test/query_operators_test.clj
@@ -125,4 +125,10 @@
            {:language {$regex "clo.*" $options "i"}} 2
            {:name     {$regex "aK.*" $options "i"}} 1
            {:language {$regex ".*by"}} 1
-           {:language {$regex ".*ala.*"}} 1))))
+           {:language {$regex ".*ala.*"}} 1)))
+
+  (deftest find-with-js-expression
+    (let [collection "people"]
+      (mc/insert-batch db collection [{:name "Bob" :placeOfBirth "New York" :address {:city "New York"}}
+                                      {:name "Alice" :placeOfBirth "New York" :address {:city "Los Angeles"}}])
+      (is (= 1 (.count (mc/find db collection {$where "this.placeOfBirth === this.address.city"})))))))

--- a/test/monger/test/query_operators_test.clj
+++ b/test/monger/test/query_operators_test.clj
@@ -58,7 +58,7 @@
   ;; $ne
   ;;
 
-  (deftest find-with-and-or-operators
+  (deftest find-with-ne-operator
     (let [collection "libraries"]
       (mc/insert-batch db collection [{:language "Ruby"    :name "mongoid"  :users 1}
                                       {:language "Clojure" :name "langohr"  :users 5}

--- a/test/monger/test/query_operators_test.clj
+++ b/test/monger/test/query_operators_test.clj
@@ -55,6 +55,18 @@
            1 {:users {$gt 10 $lt 150}})))
 
   ;;
+  ;; $eq
+  ;;
+
+  (deftest find-with-eq-operator
+    (let [collection "libraries"]
+      (mc/insert-batch db collection [{:language "Ruby"    :name "mongoid"  :users 1 :displayName nil}
+                                      {:language "Clojure" :name "langohr"  :users 5}
+                                      {:language "Clojure" :name "incanter" :users 15}
+                                      {:language "Scala"   :name "akka"     :users 150}])
+      (is (= 2 (.count (mc/find db collection {:language {$eq "Clojure"}}))))))
+
+  ;;
   ;; $ne
   ;;
 


### PR DESCRIPTION
I added a test that there is an operator for every static field of [com.mongodb.QueryOperators](https://api.mongodb.com/java/current/com/mongodb/QueryOperators.html#field.summary). I hope the test helps maintaining `monger.operators` if/when new driver versions define new operators.

The test failed initially so I added the missing geospatial operators and the `$where` operator, but skipped those operators that were documented to be deprecated. 

While at it I also added `$eq` (fixes #112) and `$isolated` (which I have a use case for).

The test for `$ne` operator was broken, fixed that and the comment mentioned in #87 too.