### PR TITLE
Close GridFSInputFile input stream on persist

### DIFF
--- a/src/clojure/monger/gridfs.clj
+++ b/src/clojure/monger/gridfs.clj
@@ -116,7 +116,7 @@
 
 (defn ^GridFSInputFile make-input-file
   [^GridFS fs input]
-  (.createFile fs (to-input-stream input)))
+  (.createFile fs (to-input-stream input) true))
 
 (defmacro store
   [^GridFSInputFile input & body]

--- a/src/clojure/monger/gridfs.clj
+++ b/src/clojure/monger/gridfs.clj
@@ -114,9 +114,30 @@
   (to-input-stream [^InputStream input]
     input))
 
+(defprotocol GridFSInputFileFactory
+  (^GridFSInputFile create-gridfs-file [input ^GridFS fs] "Creates a file entry"))
+
+(extend byte-array-type
+  GridFSInputFileFactory
+  {:create-gridfs-file (fn [^bytes input ^GridFS fs]
+                         (.createFile fs input))})
+
+(extend-protocol GridFSInputFileFactory
+  String
+  (create-gridfs-file [^String input ^GridFS fs]
+    (.createFile fs (io/file input)))
+
+  File
+  (create-gridfs-file [^File input ^GridFS fs]
+    (.createFile fs input))
+
+  InputStream
+  (create-gridfs-file [^InputStream input ^GridFS fs]
+    (.createFile fs input)))
+
 (defn ^GridFSInputFile make-input-file
   [^GridFS fs input]
-  (.createFile fs (to-input-stream input) true))
+  (create-gridfs-file input fs))
 
 (defmacro store
   [^GridFSInputFile input & body]

--- a/test/monger/test/gridfs_test.clj
+++ b/test/monger/test/gridfs_test.clj
@@ -78,6 +78,16 @@
                   (content-type "application/octet-stream"))
       (is (= 1 (count (gridfs/all-files fs))))))
 
+  (deftest ^{:gridfs true} test-deleting-file-instance-on-disk-after-storing
+    (let [tmp-file (File/createTempFile "monger.test.gridfs" "test-deleting-file-instance-on-disk-after-storing")
+          _        (spit tmp-file "to be deleted")]
+      (is (= 0 (count (gridfs/all-files fs))))
+      (store-file (make-input-file fs tmp-file)
+                  (filename "test-deleting-file-instance-on-disk-after-storing")
+                  (content-type "application/octet-stream"))
+      (is (= 1 (count (gridfs/all-files fs))))
+      (is (.delete tmp-file))))
+
 
 
   (deftest ^{:gridfs true} test-finding-individual-files-on-gridfs


### PR DESCRIPTION
`monger.gridfs/make-input-file` converts all input types to InputStreams and passes the stream to [GridFS/createFile](https://api.mongodb.com/java/current/com/mongodb/gridfs/GridFS.html#createFile-java.io.InputStream-). The Java driver does not set closeStreamOnPersist flag on the new GridFSInputFile when called this way.

If the input to `monger.gridfs/make-input-file` is a File, the InputStream created by `monger.gridfs/make-input-stream` does not get closed at all. For example on Windows this prevents the file from being deleted after it is stored (see the added test).

I propose that we tell the driver to always close the InputStream after persist. In my opinion this would be a reasonable default. However, there is a small change that this would break some client code, if a client already wraps store-file call in a with-open and uses some sort of InputStream that does not implement `close` idempotently:

```
(with-open [input unorthodox-input-stream]
  (store-file (store-file (make-input-file fs input))
) ; close is called a second time on input, SHOULD be idempotent and cause no harm
```

If you think this is something we should worry about, another approach would be to create the GridFSInputFile directly from a File or byte array, but this would require more refactoring.