### PR TITLE
Exclude clojure.core/any? to prevent warnings on Clojure 1.9

### DIFF
--- a/src/clojure/monger/collection.clj
+++ b/src/clojure/monger/collection.clj
@@ -50,7 +50,7 @@
    * http://clojuremongodb.info/articles/updating.html
    * http://clojuremongodb.info/articles/deleting.html
    * http://clojuremongodb.info/articles/aggregation.html"
-  (:refer-clojure :exclude [find remove count drop distinct empty? update])
+  (:refer-clojure :exclude [find remove count drop distinct empty? any? update])
   (:import [com.mongodb Mongo DB DBCollection WriteResult DBObject WriteConcern
             DBCursor MapReduceCommand MapReduceCommand$OutputType AggregationOutput
             AggregationOptions AggregationOptions$OutputMode]


### PR DESCRIPTION
We're using monger with Clojure 1.9.0-alpha14.

In 1.9 there's a new function, [`clojure.core/any?`](https://clojuredocs.org/clojure.core/any_q) that clashes with `monger.collection/any?`, resulting in warnings:

```
WARNING: any? already refers to: #'clojure.core/any? in namespace: monger.collection, being replaced by: #'monger.collection/any?
```

This PR adds `any?` to the symbols excluded from `:refer-clojure`.