### PR TITLE
Update dependencies to support MongoDB 3.4.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure        "1.8.0"]
-                 [org.mongodb/mongodb-driver "3.3.0"]
+                 [org.mongodb/mongodb-driver "3.4.2"]
                  [clojurewerkz/support       "1.1.0"]]
   :test-selectors {:default     (fn [m]
                                   (and (not (:performance m))
@@ -27,7 +27,7 @@
                    :all           (constantly true)}
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]
-  :javac-options     ["-target" "1.6" "-source" "1.6"]
+  :javac-options     ["-target" "1.7" "-source" "1.7"]
   :mailing-list {:name "clojure-mongodb"
                  :archive "https://groups.google.com/group/clojure-mongodb"
                  :post "clojure-mongodb@googlegroups.com"}


### PR DESCRIPTION
In order for Monger to work with MongoDB 3.4.x and higher, the Java driver must also be 3.4.x and higher.  Additionally, the 3.4.x driver series will generally work with Java version 6.x, it requires 7.x, and even 8.x for specific SSL functions that are needed by some "Platform As A Service" providers such as MongoDB Atlas.  Here are some relevant links that provide some additional details: 

- http://mongodb.github.io/mongo-java-driver/3.4/upgrading/
- https://docs.atlas.mongodb.com/driver-connection/#java-driver-example
- http://mongodb.github.io/mongo-java-driver/?_ga=2.85301265.905224850.1494354505-76319364.1488584191