### PR TITLE
Upgrade mongo drivers to 3.8.0 GA version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure        "1.8.0"]
-                 [org.mongodb/mongodb-driver "3.6.0-beta2"]
+                 [org.mongodb/mongodb-driver "3.8.0"]
                  [clojurewerkz/support       "1.1.0"]]
   :test-selectors {:default     (fn [m]
                                   (and (not (:performance m))


### PR DESCRIPTION
I'm trying to upgrade with latest mongoDB drivers for Java. 
In case these drivers are breaking the tests I'll try with former `3.7.1` or `3.6.4` drivers version.
This PR is a required milestone for #165 