### PR TITLE
Try to use openjdk for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_script:
   - ./bin/ci/before_script.sh
 script: lein do clean, javac, test
 jdk:
-  - oraclejdk10
+  - openjdk10
   - oraclejdk11
-  - oraclejdk12  
+  - openjdk12
 services:
   - mongodb
 branches:


### PR DESCRIPTION
Neither oraclejdk 10 nor 12 is available on travis anymore, so we try to use openjdk instead.