### PR TITLE
Add uuid-representation option

### DIFF
--- a/src/clojure/monger/core.clj
+++ b/src/clojure/monger/core.clj
@@ -145,7 +145,7 @@
            max-wait-time min-connections-per-host min-heartbeat-frequency read-concern read-preference
            required-replica-set-name retry-writes server-selection-timeout server-selector socket-keep-alive 
            socket-factory socket-timeout ssl-context ssl-enabled ssl-invalid-host-name-allowed
-           threads-allowed-to-block-for-connection-multiplier write-concern]}]
+           threads-allowed-to-block-for-connection-multiplier uuid-representation write-concern]}]
   (let [mob (MongoClientOptions$Builder.)]
     (when add-cluster-listener
       (.addClusterListener mob add-cluster-listener))
@@ -238,6 +238,8 @@
       (.sslInvalidHostNameAllowed mob ssl-invalid-host-name-allowed))
     (when threads-allowed-to-block-for-connection-multiplier
       (.threadsAllowedToBlockForConnectionMultiplier mob threads-allowed-to-block-for-connection-multiplier))
+    (when uuid-representation
+      (.uuidRepresentation mob uuid-representation))
     (when write-concern
       (.writeConcern mob write-concern))
     mob))

--- a/test/monger/test/core_test.clj
+++ b/test/monger/test/core_test.clj
@@ -80,6 +80,7 @@
               :ssl-enabled true
               :ssl-invalid-host-name-allowed true
               :threads-allowed-to-block-for-connection-multiplier 1
+              :uuid-representation org.bson.UuidRepresentation/STANDARD
               :write-concern com.mongodb.WriteConcern/JOURNAL_SAFE}]
     (is (instance? com.mongodb.MongoClientOptions$Builder (mg/mongo-options-builder opts)))))
 


### PR DESCRIPTION
Fixes #212.

Adds `uuid-representation` option which corresponds to `MongoClientOptions$Builder.uuidRepresentation`.

Makes no attempt to coerce or convert the option value; a `org.bson.UuidRepresentation` must be passed.