### PR TITLE
:exclude random-uuid

### DIFF
--- a/src/clojure/monger/util.clj
+++ b/src/clojure/monger/util.clj
@@ -38,7 +38,8 @@
            org.bson.types.ObjectId
            com.mongodb.DBObject
            clojure.lang.IPersistentMap
-           java.util.Map))
+           java.util.Map)
+  (:refer-clojure :exclude [random-uuid]))
 
 ;;
 ;; API


### PR DESCRIPTION
Should prevent this message when compiling:

> WARNING: random-uuid already refers to: #'clojure.core/random-uuid in namespace: monger.util, being replaced by: #'monger.util/random-uuid