### PR TITLE
Feat: supporting 3-ary clojure.data.json/write in newer versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
              :dev {:resource-paths ["test/resources"]
                    :dependencies  [[clj-time               "0.15.1" :exclusions [org.clojure/clojure]]
                                    [cheshire               "5.8.1" :exclusions [org.clojure/clojure]]
-                                   [org.clojure/data.json  "0.2.6" :exclusions [org.clojure/clojure]]
+                                   [org.clojure/data.json  "2.5.0" :exclusions [org.clojure/clojure]]
                                    [org.clojure/tools.cli  "0.4.1" :exclusions [org.clojure/clojure]]
                                    [org.clojure/core.cache "0.7.1" :exclusions [org.clojure/clojure]]
                                    [ring/ring-core         "1.7.1" :exclusions [org.clojure/clojure]]

--- a/src/clojure/monger/json.clj
+++ b/src/clojure/monger/json.clj
@@ -70,13 +70,19 @@
             (try
               (extend-protocol clojure.data.json/JSONWriter
                 ObjectId
-                (-write [^ObjectId object out]
-                  (clojure.data.json/write (.toString object) out)))
+                (-write
+                  ([^ObjectId object out]
+                   (clojure.data.json/write (.toString object) out))
+                  ([^ObjectId object out options]
+                   (clojure.data.json/write (.toString object) out options))))
 
               (extend-protocol clojure.data.json/JSONWriter
                 BSONTimestamp
-                  (-write [^BSONTimestamp object out]
-                    (clojure.data.json/write {:time (.getTime object) :inc (.getInc object)} out)))
+                (-write
+                  ([^BSONTimestamp object out]
+                   (clojure.data.json/write {:time (.getTime object) :inc (.getInc object)} out))
+                  ([^BSONTimestamp object out options]
+                   (clojure.data.json/write {:time (.getTime object) :inc (.getInc object)} out options))))
 
               (catch Throwable _
                 false))


### PR DESCRIPTION
Starting at 2.0.0, `clojure.data.json` implements the additional parameter `options` in `write` and other functions. When requiring `monger.json` and trying to write an ObjectId as json

```clojure
(json/write-str (ObjectId.))
```

The code breaks with

```text
Unhandled clojure.lang.ArityException
   Wrong number of args (3) passed to: monger.json/eval12097/fn--12098
```

A 3-ary definition was added to `-write` in `extent-protocol` in addition to the 2-ary to support older and newer versions.

PS: It is my first PR here. Let me know if I am missing something.