### PR TITLE
Add MongoDB shell version detection to before scripts

### DIFF
--- a/bin/ci/before_script.sh
+++ b/bin/ci/before_script.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
+# Check which MongoDB shell is available
+if command -v mongosh >/dev/null 2>&1; then
+    MONGO_SHELL="mongosh"
+elif command -v mongo >/dev/null 2>&1; then
+    MONGO_SHELL="mongo"
+else
+    echo "Error: Neither mongo nor mongosh shell found. Please install MongoDB shell."
+    exit 1
+fi
+
 # MongoDB Java driver won't run authentication twice on the same DB instance,
 # so we need to use multiple DBs.
-mongo --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test
-mongo --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test2
-mongo --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test3
-mongo --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test4
+$MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test
+$MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test2
+$MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test3
+$MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test4

--- a/bin/ci/before_script_docker.sh
+++ b/bin/ci/before_script_docker.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
+# Check which MongoDB shell is available in the container
+if docker exec mongo_test which mongosh >/dev/null 2>&1; then
+    MONGO_SHELL="mongosh"
+elif docker exec mongo_test which mongo >/dev/null 2>&1; then
+    MONGO_SHELL="mongo"
+else
+    echo "Error: Neither mongo nor mongosh shell found in the container."
+    exit 1
+fi
+
 # MongoDB Java driver won't run authentication twice on the same DB instance,
 # so we need to use multiple DBs.
-docker exec mongo_test mongosh --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test
-docker exec mongo_test mongosh --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test2
-docker exec mongo_test mongosh --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test3
-docker exec mongo_test mongosh --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test4
+docker exec mongo_test $MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test
+docker exec mongo_test $MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test2
+docker exec mongo_test $MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test3
+docker exec mongo_test $MONGO_SHELL --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' monger-test4


### PR DESCRIPTION
#### MongoDB Shell Compatibility

The scripts in `bin/ci` support both legacy `mongo` shell and modern `mongosh` (MongoDB 5.0+):
- Automatically detects available MongoDB shell
- Works with both `mongo` and `mongosh` commands

This is useful while running the test case. 