### PR TITLE
ci: replace dead Travis with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,77 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - 11
+          - 17
+          - 21
+        lein-version:
+          - latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+
+      - name: Set up Leiningen
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          lein: ${{ matrix.lein-version }}
+
+      - name: Provision MongoDB test users
+        run: |
+          set -eu
+
+          # Use the shell inside the MongoDB service container instead of installing MongoDB tools on the runner.
+          mongo_container='${{ job.services.mongo.id }}'
+
+          for attempt in $(seq 1 30); do
+            if docker exec "$mongo_container" mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
+              mongo_shell=mongosh
+              break
+            fi
+
+            if docker exec "$mongo_container" mongo --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
+              mongo_shell=mongo
+              break
+            fi
+
+            sleep 1
+          done
+
+          if [ -z "${mongo_shell:-}" ]; then
+            echo "Error: Neither mongo nor mongosh shell found in the MongoDB service container."
+            exit 1
+          fi
+
+          for db in monger-test monger-test2 monger-test3 monger-test4; do
+            docker exec "$mongo_container" "$mongo_shell" --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' "$db"
+          done
+
+      - name: Run tests
+        run: lein do clean, javac, test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      mongo:
-        image: mongo
-        ports:
-          - 27017:27017
-
     strategy:
       fail-fast: false
       matrix:
@@ -43,35 +37,14 @@ jobs:
         with:
           lein: ${{ matrix.lein-version }}
 
+      - name: Start MongoDB
+        run: docker run -d --name mongo_test -p 27017:27017 mongo
+
+      - name: Wait for MongoDB
+        run: ./bin/ci/wait_for_mongo.sh
+
       - name: Provision MongoDB test users
-        run: |
-          set -eu
-
-          # Use the shell inside the MongoDB service container instead of installing MongoDB tools on the runner.
-          mongo_container='${{ job.services.mongo.id }}'
-
-          for attempt in $(seq 1 30); do
-            if docker exec "$mongo_container" mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
-              mongo_shell=mongosh
-              break
-            fi
-
-            if docker exec "$mongo_container" mongo --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
-              mongo_shell=mongo
-              break
-            fi
-
-            sleep 1
-          done
-
-          if [ -z "${mongo_shell:-}" ]; then
-            echo "Error: Neither mongo nor mongosh shell found in the MongoDB service container."
-            exit 1
-          fi
-
-          for db in monger-test monger-test2 monger-test3 monger-test4; do
-            docker exec "$mongo_container" "$mongo_shell" --eval 'db.createUser({"user": "clojurewerkz/monger", "pwd": "monger", roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})' "$db"
-          done
+        run: ./bin/ci/before_script_docker.sh
 
       - name: Run tests
         run: lein do clean, javac, test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Monger, a modern Clojure MongoDB Driver
-[![Build Status](https://travis-ci.org/xingzhefeng/monger.svg?branch=master)](https://travis-ci.org/xingzhefeng/monger)
+[![Test](https://github.com/michaelklishin/monger/actions/workflows/test.yml/badge.svg)](https://github.com/michaelklishin/monger/actions/workflows/test.yml)
 Monger is an idiomatic [Clojure MongoDB driver](http://clojuremongodb.info) for a more civilized age.
 
 It has batteries included, offers powerful expressive query DSL,

--- a/bin/ci/wait_for_mongo.sh
+++ b/bin/ci/wait_for_mongo.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Waits for the mongo_test container to accept connections before the
+# test-user provisioning step runs against it.
+
+for attempt in $(seq 1 30); do
+    if docker exec mongo_test mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
+        exit 0
+    fi
+
+    if docker exec mongo_test mongo --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
+        exit 0
+    fi
+
+    sleep 1
+done
+
+echo "Error: timed out waiting for MongoDB to accept connections." >&2
+exit 1


### PR DESCRIPTION
## Summary
- `.travis.yml` currently produces zero check-runs / commit status on `main` (Travis dropped free OSS builds years ago), so this repo effectively has no CI signal today.
- Adds `.github/workflows/test.yml` that replicates the existing Travis setup faithfully:
  - Same `mongo` service container from `docker-compose.yml`, exposed on 27017.
  - Same multi-DB user provisioning `bin/ci/before_script.sh` performs (`monger-test` / `monger-test2` / `monger-test3` / `monger-test4`, same user/roles/mechanism), execed straight into the service container instead of installing Mongo tooling on the runner.
  - Same `lein do clean, javac, test` invocation.
- Java matrix modernized from `openjdk10` / `oraclejdk11` / `openjdk12` to `11` / `17` / `21`.
- `.travis.yml` is left in place, happy to remove it in a follow-up if you'd rather, wanted to keep this PR to the additive change only.

## Test plan
- [x] Ran the exact provisioning + test sequence locally (Docker `mongo` container, same 4 `createUser` calls, then `lein do clean, javac, test`): 242 tests, 624 assertions, 0 failures, 0 errors.
- [ ] CI run?